### PR TITLE
Adds full name as a user field

### DIFF
--- a/src/base/Provider.php
+++ b/src/base/Provider.php
@@ -211,6 +211,10 @@ abstract class Provider extends SavableComponent implements ProviderInterface
                 'handle' => 'lastName',
             ]),
             new UserField([
+                'name' => 'Full Name',
+                'handle' => 'fullName',
+            ]),
+            new UserField([
                 'name' => 'Photo',
                 'handle' => 'photo',
                 'type' => UserField::TYPE_FILE_UPLOAD,


### PR DESCRIPTION
Hi, this PR adds the option to map a Full Name, for cases where the Provider response also has full names rather than separate first and last names.

<img width="849" alt="Screen Shot 2023-11-01 at 11 22 05 AM" src="https://github.com/verbb/social-login/assets/1581276/cf56ad26-f8a7-4ca7-919c-4d154d2a051a">

For what it’s worth, I wasn’t able to get the Name field set to anything for this use case. It only worked once I used First Name, which Craft turned into the Full Name, or added this Full Name field.

Thanks!