### PR TITLE
[Feature] Sync User Profiles

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -16,6 +16,7 @@ class Settings extends Model
     public bool $enableRegistration = true;
     public array $userGroups = [];
     public bool $populateProfile = true;
+    public bool $syncProfile = true;
     public bool $forceActivate = true;
 
     public array $providers = [];

--- a/src/services/Users.php
+++ b/src/services/Users.php
@@ -135,10 +135,9 @@ class Users extends Component
         if ($user) {
             // Check if the User profile should be remapped
             if ($settings->populateProfile && $settings->syncProfile) {
-                $this->_syncUserProfile($provider, $user, $userProfile);
+                $user = $this->_syncUserProfile($provider, $user, $userProfile);
+                Craft::$app->getElements()->saveElement($user);
             }
-
-            Craft::$app->getElements()->saveElement($user);
 
             return $user;
         }
@@ -222,13 +221,13 @@ class Users extends Component
         $user->email = $userProfile->email;
 
         if ($settings->populateProfile) {
-            $this->_syncUserProfile($provider, $user, $userProfile);
+            $user = $this->_syncUserProfile($provider, $user, $userProfile);
         }
 
         return $user;
     }
 
-    private function _syncUserProfile(Provider $provider, User $user, UserProfile $userProfile) {
+    private function _syncUserProfile(Provider $provider, User $user, UserProfile $userProfile): User {
         $userFields = $provider->getCraftUserFields();
 
         foreach (array_filter($provider->fieldMapping) as $attribute => $profile) {

--- a/src/services/Users.php
+++ b/src/services/Users.php
@@ -138,6 +138,8 @@ class Users extends Component
                 $this->_syncUserProfile($provider, $user, $userProfile);
             }
 
+            Craft::$app->getElements()->saveElement($user);
+
             return $user;
         }
 

--- a/src/services/Users.php
+++ b/src/services/Users.php
@@ -133,6 +133,11 @@ class Users extends Component
         $user = $this->_matchExistingUser($provider, $userProfile);
 
         if ($user) {
+            // Check if the User profile should be remapped
+            if ($settings->populateProfile && $settings->syncProfile) {
+                $this->_syncUserProfile($provider, $user, $userProfile);
+            }
+
             return $user;
         }
 
@@ -215,44 +220,50 @@ class Users extends Component
         $user->email = $userProfile->email;
 
         if ($settings->populateProfile) {
-            $userFields = $provider->getCraftUserFields();
+            $this->_syncUserProfile($provider, $user, $userProfile);
+        }
 
-            foreach (array_filter($provider->fieldMapping) as $attribute => $profile) {
-                $value = null;
+        return $user;
+    }
 
-                try {
-                    // Get the raw value from the provider. UserProfile smart enough to return `null`.
-                    $value = $userProfile->$profile;
+    private function _syncUserProfile(Provider $provider, User $user, UserProfile $userProfile) {
+        $userFields = $provider->getCraftUserFields();
 
-                    // Get the destination field/attribute UserField model to parse mapping
-                    $userField = ArrayHelper::firstWhere($userFields, 'handle', $attribute) ?? UserField::TYPE_STRING;
+        foreach (array_filter($provider->fieldMapping) as $attribute => $profile) {
+            $value = null;
 
-                    // Get the parsed value
-                    $value = $this->_getFieldMappingValue($user, $userField, $value);
+            try {
+                // Get the raw value from the provider. UserProfile smart enough to return `null`.
+                $value = $userProfile->$profile;
 
-                    if (!$value) {
-                        continue;
-                    }
+                // Get the destination field/attribute UserField model to parse mapping
+                $userField = ArrayHelper::firstWhere($userFields, 'handle', $attribute) ?? UserField::TYPE_STRING;
 
-                    $isField = str_starts_with($attribute, 'field:');
-                    $attribute = str_replace('field:', '', $attribute);
+                // Get the parsed value
+                $value = $this->_getFieldMappingValue($user, $userField, $value);
 
-                    if ($isField) {
-                        $user->setFieldValue($attribute, $value);
-                    } else {
-                        $user->$attribute = $value;
-                    }
-                } catch (Throwable $e) {
-                    SocialLogin::error('Error mapping field “{field}:{profile}” - “{value}” for “{provider}”: “{message}” {file}:{line}', [
-                        'value' => Json::encode($value),
-                        'field' => $attribute,
-                        'profile' => $profile,
-                        'provider' => $provider->handle,
-                        'message' => $e->getMessage(),
-                        'file' => $e->getFile(),
-                        'line' => $e->getLine(),
-                    ]);
+                if (!$value) {
+                    continue;
                 }
+
+                $isField = str_starts_with($attribute, 'field:');
+                $attribute = str_replace('field:', '', $attribute);
+
+                if ($isField) {
+                    $user->setFieldValue($attribute, $value);
+                } else {
+                    $user->$attribute = $value;
+                }
+            } catch (Throwable $e) {
+                SocialLogin::error('Error mapping field “{field}:{profile}” - “{value}” for “{provider}”: “{message}” {file}:{line}', [
+                    'value' => Json::encode($value),
+                    'field' => $attribute,
+                    'profile' => $profile,
+                    'provider' => $provider->handle,
+                    'message' => $e->getMessage(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                ]);
             }
         }
 

--- a/src/templates/settings/index.html
+++ b/src/templates/settings/index.html
@@ -76,7 +76,19 @@
             on: settings.populateProfile,
             errors: settings.getErrors('populateProfile'),
             warning: macros.configWarning('populateProfile', 'social-login'),
+            toggle: 'sync-profile',
         }) }}
+
+        <div id="sync-profile" class="{{ not settings.populateProfile ? 'hidden' }}">
+            {{ forms.lightswitchField({
+                label: 'Sync User Profile' | t('social-login'),
+                instructions: 'Whether existing users should have their profiles synced with the provider on subsequent logins.' | t('social-login'),
+                name: 'syncProfile',
+                on: settings.syncProfile,
+                errors: settings.getErrors('syncProfile'),
+                warning: macros.configWarning('syncProfile', 'social-login'),
+            }) }}
+        </div>
 
         {% set groups = [] %}
 


### PR DESCRIPTION
# Description

Currently, when a field mapping is given from a provider, that is only applied when a new Craft User is created. This PR adds a new option to the Plugin settings called `syncProfile`. If enabled, this option will also sync profile data on subsequent logins for a Craft User.

The use case here is that we want the SSO provider to hold some given User profile data which may change over time. This new option ensures that we're getting the latest data from the provider whenever a login occurs.

### Added

- New `syncProfile` plugin setting

### Changed

- Lift profile sync code to a separate function
- Call that function when creating a new Craft User or when an existing User is matched