### PR TITLE
Fixed race conditions with plugin init and bump Craft dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Fix race conditions with pluign intialisation.
+
 ## 1.0.15 - 2024-05-29
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "craftcms/cms": "^4.0.0",
+        "craftcms/cms": "^4.3.5",
         "verbb/auth": "^1.0.22",
         "verbb/base": "^2.0.0"
     },

--- a/src/SocialLogin.php
+++ b/src/SocialLogin.php
@@ -52,8 +52,11 @@ class SocialLogin extends Plugin
             $this->_registerSiteRoutes();
         }
 
-        // Check to register the plugin for CP login
-        $this->getService()->renderCpLogin();
+        // Defer most setup tasks until Craft is fully initialized:
+        Craft::$app->onInit(function() {
+            // Check to register the plugin for CP login
+            $this->getService()->renderCpLogin();
+        });
     }
 
     public function getSettingsResponse(): mixed

--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -74,33 +74,30 @@ class Service extends Component
 
     public function renderCpLogin(): void
     {
-        // Wait until plugins are loaded to check
-        Event::on(Plugins::class, Plugins::EVENT_AFTER_LOAD_PLUGINS, function(Event $event) {
-            try {
-                $settings = SocialLogin::$plugin->getSettings();
-                $request = Craft::$app->getRequest();
-                $view = Craft::$app->getView();
+        try {
+            $settings = SocialLogin::$plugin->getSettings();
+            $request = Craft::$app->getRequest();
+            $view = Craft::$app->getView();
 
-                if ($settings->enableCpLogin && $request->getIsCpRequest()) {
-                    $template = $this->_getTemplate('social-login/_includes/cp-login', $settings->cpLoginTemplate);
+            if ($settings->enableCpLogin && $request->getIsCpRequest()) {
+                $template = $this->_getTemplate('social-login/_includes/cp-login', $settings->cpLoginTemplate);
 
-                    if ($template) {
-                        $html = $view->renderTemplate($template);
+                if ($template) {
+                    $html = $view->renderTemplate($template);
 
-                        $view->registerAssetBundle(SocialLoginAsset::class);
-                        $view->registerJs('new Craft.SocialLogin.CpLoginForm(' . Json::encode([
-                            'html' => $html,
-                        ]) . ');');
-                    }
+                    $view->registerAssetBundle(SocialLoginAsset::class);
+                    $view->registerJs('new Craft.SocialLogin.CpLoginForm(' . Json::encode([
+                        'html' => $html,
+                    ]) . ');');
                 }
-            } catch (Throwable $e) {
-                SocialLogin::error('Unable to render CP Login template: “{message}” {file}:{line}', [
-                    'message' => $e->getMessage(),
-                    'file' => $e->getFile(),
-                    'line' => $e->getLine(),
-                ]);
             }
-        });
+        } catch (Throwable $e) {
+            SocialLogin::error('Unable to render CP Login template: “{message}” {file}:{line}', [
+                'message' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
+        }
     }
 
 


### PR DESCRIPTION
Similar to the changes you made in the Craft 5 compatibility, the Craft 4 version of the plugin needs to take advantage of the `onInit()` method to prevent conflicts with other plugins and Craft.

There is a need for a bump in the Craft dependency as that method was only added in Craft `4.3.5`.

The changes in the PR are a replication of those that are on the `craft-5` branch.

Apologies, I haven't had time to fully test it, however, I am sure you have a test suite set up to make sure this is all working.

Let me know if you need anything further!