### PR TITLE
Adds the ability to override instructions for custom providers

### DIFF
--- a/src/templates/providers/_oauth.html
+++ b/src/templates/providers/_oauth.html
@@ -1,13 +1,17 @@
 {% import '_includes/forms' as forms %}
 {% import 'verbb-base/_macros' as macros %}
 
-{% set instructions %}
-To connect to {name}, follow our <a href="https://verbb.io/craft-plugins/social-login/docs/providers/all-providers" target="_blank" rel="noopener">{name} provider guide</a>.
-{% endset %}
+{% if instructions is not defined %}
+    {%- set instructions -%}
+    To connect to {name}, follow our <a href="https://verbb.io/craft-plugins/social-login/docs/providers/all-providers" target="_blank" rel="noopener">{name} provider guide</a>.
+    {%- endset -%}
+{% endif %}
 
-<div class="ss-settings-block">
-    {{ instructions | t('social-login', { name: provider.name, plugin: 'Social Login' }) | md }}
-</div>
+{% if instructions %}
+    <div class="ss-settings-block">
+        {{ instructions | t('social-login', { name: provider.name, plugin: 'Social Login' }) | md }}
+    </div>
+{% endif %}
 
 {{ forms.textField({
     readonly: true,


### PR DESCRIPTION
This PR makes it possible to override the instructions in the provider settings template, ex:

<img width="905" alt="Screenshot 2024-06-21 at 11 52 01 AM" src="https://github.com/verbb/social-login/assets/1581276/46e1f8b7-0de0-42bb-b3ea-826c6fb777d7">

This way, when you set up a custom provider, you can still make use of this include but remove or change the setup instructions.

Thanks!