### PR TITLE
Adds arbitrary `data` feature to v1.x

### DIFF
--- a/src/controllers/AuthController.php
+++ b/src/controllers/AuthController.php
@@ -49,6 +49,9 @@ class AuthController extends Controller
             // Keep track of which provider instance is for, so we can fetch it in the callback
             Session::set('providerHandle', $providerHandle);
 
+            // Allow users to store data to be saved for later
+            Session::set('data', $this->request->getParam('data'));
+
             // Keep track of CP requests and if resuming a session
             Session::set('isCpRequest', $this->request->getIsCpRequest());
             Session::set('loginName', $this->request->getParam('loginName'));


### PR DESCRIPTION
I believe cherry-picking this commit was sufficient to bring the `data` feature from v2.0.2 into v1.x, for Craft 4.

I’m migrating from [venveo/craft-oauthclient](https://github.com/venveo/craft-oauthclient), which has a similar `context` param for passing along arbitrary data. It would be helpful for migrating if this was available in Social Login for Craft 4 too.

Thanks!