### PR TITLE
[Feature] Sync Profiles for Authenticated Users

### DIFF
--- a/src/services/Users.php
+++ b/src/services/Users.php
@@ -42,6 +42,9 @@ class Users extends Component
         // With the user authenticated, login or register
         $user = Craft::$app->getUser()->getIdentity();
 
+        // Fetch plugin settings
+        $settings = SocialLogin::$plugin->getSettings();
+
         if (!$user) {
             $user = $this->_getOrCreateUser($provider, $userProfile);
 
@@ -50,6 +53,12 @@ class Users extends Component
 
                 return false;
             }
+        } else if ($settings->populateProfile && $settings->syncProfile) {
+            // Ensure we sync the User's profile on each login/register request. This ensures profile data is synced
+            //  when using an edit profile URL from the SSO provider, for example.
+
+            $user = $this->_syncUserProfile($provider, $user, $userProfile);
+            Craft::$app->getElements()->saveElement($user);
         }
 
         // Are we resuming an already-logged in session (through the modal login)? Ensure that things match, 


### PR DESCRIPTION
# Description

Recognizing that this is likely a rare use-case, but our provider (Azure ADB2C) has a flow to edit & update User profile data. A user can access that flow via a link in the Craft template. Once they are sent back to Craft via the `auth/callback` URL, their updated profile data is not synced because that currently only happens during `_getOrCreateUser()`.

This PR adds a conditional to ensure that the SSO profile is synced even if the User is already authenticated on the Craft side.

### Changed

- Always make a call to `_syncUserProfile()` if `populateProfile` and `syncProfile` are true, regardless of User status